### PR TITLE
version two

### DIFF
--- a/CareLink.psd1
+++ b/CareLink.psd1
@@ -12,7 +12,7 @@
     RootModule = 'CareLink.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0'
+    ModuleVersion = '2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -74,7 +74,8 @@
         'Confirm-CareLinkToken',
         'Get-CareLinkAccount',
         'Get-CareLinkProfile',
-        'Get-CareLinkData'
+        'Get-CareLinkData',
+        'Set-CareLinkToken'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/CareLink.psm1
+++ b/CareLink.psm1
@@ -130,30 +130,37 @@ function Get-CareLinkAccount {
 
 #retrieve user profile information, username, phone number, etc.
 function Get-CareLinkProfile {
-    param (
-        #The Carelink username
-        [parameter(Mandatory = $true, Position = 0)]
-        [PSCustomObject]$Token
-    )
+  <#
+  param (
+    #The Carelink username
+    [parameter(Mandatory = $true, Position = 0)]
+    [PSCustomObject]$Token
+  )
+  #>
 
+  if ($script:CareLinkToken) {
     #verify the token is still valid before proceding
-    $token = Confirm-CarelinkToken -Token $token
+    $token = Confirm-CarelinkToken -Token $script:CareLinkToken
 
     $authHeader = @{
-        "Accept"          = "application/json, text/plain, */*"
-        "Accept-Encoding" = "gzip, deflate, br"
-        "Accept-Language" = "en-US,en;q=0.6"
-        "Authorization"   = "Bearer $($Token.Token.value)"
-        "Referer"         = "https://carelink.minimed.com/app/home"
-        "Sec-Fetch-Dest"  = "empty"
-        "Sec-Fetch-Mode"  = "cors"
-        "Sec-Fetch-Site"  = "same-origin"
-        "Sec-GPC"         = "1"
-      }
+      "Accept"          = "application/json, text/plain, */*"
+      "Accept-Encoding" = "gzip, deflate, br"
+      "Accept-Language" = "en-US,en;q=0.6"
+      "Authorization"   = "Bearer $($script:CareLinkToken.token)"
+      "Referer"         = "https://carelink.minimed.com/app/home"
+      "Sec-Fetch-Dest"  = "empty"
+      "Sec-Fetch-Mode"  = "cors"
+      "Sec-Fetch-Site"  = "same-origin"
+      "Sec-GPC"         = "1"
+    }
 
     #call the Me rest endpoint
-    $me = Invoke-RestMethod -Uri "https://carelink.minimed.com/patient/users/me/profile" -Method "GET" -header $authHeader -UserAgent $token.userAgent -WebSession $token.websession
+    $me = Invoke-RestMethod -Uri "https://carelink.minimed.com/patient/users/me/profile" -Method "GET" -header $authHeader -UserAgent $token.userAgent #-WebSession $token.websession
     return $me
+  }
+  else {
+    Write-Error "Token is not defined. Please retrieve a token, expiration date, and then set it with Set-CareLinkToken"
+  }
 }
 
 function Get-CareLinkData {

--- a/CareLink.psm1
+++ b/CareLink.psm1
@@ -95,30 +95,37 @@ function Get-CareLinkToken {
 
 #retrieve user account information such as their Login Date, Account ID, and User Role
 function Get-CareLinkAccount {
-    param (
-        #The Carelink username
-        [parameter(Mandatory = $true, Position = 0)]
-        [PSCustomObject]$Token
-    )
+  <#
+  param (
+    #The Carelink username
+    [parameter(Mandatory = $true, Position = 0)]
+    [PSCustomObject]$Token
+  )
+  #>
 
+  if ($script:CareLinkToken) {
     #verify the token is still valid before proceding
-    $token = Confirm-CarelinkToken -Token $token
+    $token = Confirm-CarelinkToken -Token $script:CareLinkToken
 
     $authHeader = @{
-        "Accept"          = "application/json, text/plain, */*"
-        "Accept-Encoding" = "gzip, deflate, br"
-        "Accept-Language" = "en-US,en;q=0.6"
-        "Authorization"   = "Bearer $($Token.Token.value)"
-        "Referer"         = "https://carelink.minimed.com/app/home"
-        "Sec-Fetch-Dest"  = "empty"
-        "Sec-Fetch-Mode"  = "cors"
-        "Sec-Fetch-Site"  = "same-origin"
-        "Sec-GPC"         = "1"
-      }
+      "Accept"          = "application/json, text/plain, */*"
+      "Accept-Encoding" = "gzip, deflate, br"
+      "Accept-Language" = "en-US,en;q=0.6"
+      "Authorization"   = "Bearer $($script:CareLinkToken.token)"
+      "Referer"         = "https://carelink.minimed.com/app/home"
+      "Sec-Fetch-Dest"  = "empty"
+      "Sec-Fetch-Mode"  = "cors"
+      "Sec-Fetch-Site"  = "same-origin"
+      "Sec-GPC"         = "1"
+    }
 
     #call the Me rest endpoint
-    $me = Invoke-RestMethod -Uri "https://carelink.minimed.com/patient/users/me" -Method "GET" -header $authHeader -UserAgent $token.userAgent -WebSession $token.websession
+    $me = Invoke-RestMethod -Uri "https://carelink.minimed.com/patient/users/me" -Method "GET" -header $authHeader -UserAgent $token.userAgent #-WebSession $token.websession
     return $me
+  }
+  else {
+    Write-Error "Token is not defined. Please retrieve a token, expiration date, and then set it with Set-CareLinkToken"
+  }
 }
 
 #retrieve user profile information, username, phone number, etc.

--- a/CareLink.psm1
+++ b/CareLink.psm1
@@ -6,7 +6,8 @@ This PowerShell module emulates browser interaction to Minimed CareLink to retri
 #>
 
 function Get-CareLinkToken {
-    param (
+  <#
+      param (
         #The Carelink username
         [parameter(ParameterSetName = 'ManualCred', Mandatory = $true, Position = 0)]
         [string]$username,
@@ -82,6 +83,14 @@ function Get-CareLinkToken {
     }
 
     return $token
+    #>
+
+  if ($script:CarelinkToken) {
+    return $script:CarelinkToken
+  }
+  else {
+    return "Token has not been declared. Use Set-CareLinkToken to define it"
+  }
 }
 
 #retrieve user account information such as their Login Date, Account ID, and User Role

--- a/CareLink.psm1
+++ b/CareLink.psm1
@@ -295,3 +295,32 @@ function Confirm-CareLinkToken {
     Write-Error "Token is not defined. Please retrieve a token, expiration date, and then set it with Set-CareLinkToken"
   }
 }
+
+function Set-CareLinkToken {
+  <#
+    .SYNOPSIS
+        Set the Carelink Token and Expiration values
+    .DESCRIPTION
+        In order to retrieve data from carelink, you must authenticate with a browser so as to retrieve a valid Token ("auth_tmp_token") and
+        Token Expiration Date ("c_token_valid_to").
+
+        For example, using Dev Tools, copy the Token and Token Expiration date out. Using this cmdlet, you can set those values.
+    .EXAMPLE
+        Set-CareLinkToken -Expiration "Fri Nov 20 19:17:44 UTC 2023" -Token "c7822ebd1d9bf24609b7..."
+  #>
+
+  param (
+    #The Expiration DateTime of the token. For example, Mon Nov 20 01:36:04 UTC 2023
+    [parameter(Mandatory = $true, Position = 0)]
+    [string]$Expiration,
+    #The token to use when making calls to retrieve data, and request new tokens
+    [parameter(Mandatory = $true, Position = 1)]
+    [string]$Token
+  )
+
+  #set the carelink token variable to use within the module
+  $script:CarelinkToken = [PSCustomObject]@{
+    Expiration = "$Expiration"
+    Token      = "$Token"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This module is compatible with PowerShell 5.1 and up. It has been tested and con
 
 | Cmdlet                |    Purpose    |
 | --------------------- | ------------- |
-| Get-CareLinkToken     | Authenticates to Carelink using your username/password  |
+| Get-CareLinkToken     | Retrieves the token currently in use  |
+| Set-CareLinkToken     | Sets the token and expiration date to use in subsequent cmdlets  |
 | Confirm-CareLinkToken | Used by other functions to confirm your authentication to Carelink is still valid |
 | Get-CareLinkAccount   | Retrieves information about your account such as login date, account id, and user role |
 | Get-CareLinkProfile   | Retrieves information about your profile such as username, phone number, email, etc. |

--- a/README.md
+++ b/README.md
@@ -35,39 +35,28 @@ Install-Module -Name CareLink
 
 ## Authenticate to CareLink
 
-This cmdlet can be used one of two ways to sign into CareLink.
-1. Enter your username and password as values to the Get-CareLinkToken cmdlet. Then store this in a variable, for example called $token.
+In order to retrieve data, you must first obtain an access token and its expiration date. One means of doing this is:
+1. Open a browser
+2. Log into CareLink
+3. Push F12 to open up Developer Tools and navigate to the Network Tab
+4. Then in CareLink navigate to Data Connect to view your live glucose data
+5. In the list of calls made in the Network tab, filter down for one called "message"
+
+Inspect the Headers to copy out the Token and the Token's Expiration Date. You're looking for values that correspond with "c_token_valid_to" and "auth_tmp_token". Then paste them into the following cmdlet.
 
 ```powershell
-$token = Get-CareLinkToken -username "???????" -password "????????"
-```
-It should be noted that entering credentials in plaintext within a script 100% violates PowerShell best practices. To curb this, it's recommended to use the PowerShell Secrets module to safely store and consume credentials on your computer. Installing and use is simple:
-```powershell
-#install the module, only need to do this once
-Install-Module -Name Microsoft.PowerShell.SecretManagement -Repository PSGallery
-#store the password. You can run the identical cmdlet every time you ever want to update the value
-Set-Secret -Name "CarelinkPW"
-
-#consume the secret
-$carelinkpassword = Get-Secret -Name "CarelinkPW" -AsPlainText
-$token = Get-CareLinkToken -username "???????" -password "$carelinkpassword"
+Set-CareLinkToken -Expiration "Fri Nov 20 19:17:44 UTC 2023" -Token "c7822ebd1d9bf24609b7..."
 ```
 
-or
-
-2. Use of a PSCredential. This will prompt you to enter credentials everytime.
-```powershell
-$creds = Get-Credential
-$token = Get-CareLinkToken -credential $creds
-```
+Tokens are good for approximatley 40 minutes
 
 ## Get account/profile details
 
 Once you have a token, use it with subsequent cmdlets to retrieve more information such as your Account and Profile information. You'll ultimately need these to access your sugar data.
 
 ```powershell
-$account = Get-CarelinkAccount -token $token
-$userProfile = Get-CarelinkProfile -token $token
+$account = Get-CarelinkAccount
+$userProfile = Get-CarelinkProfile
 ```
 
 ## Retrieve last sugar, last 24 hours of sugar, device serial number, etc.
@@ -75,7 +64,7 @@ $userProfile = Get-CarelinkProfile -token $token
 Using the $token, $account, and $userProfile variables. Pass them as values to the Get-CareLinkData cmdlet to retrieve pertinent information. Save the entire object to a variable such as $data to explore.
 
 ```powershell
-$data = Get-CarelinkData -Token $token -CarelinkUserAccount $account -CarelinkUserProfile $userProfile
+$data = Get-CarelinkData -CarelinkUserAccount $account -CarelinkUserProfile $userProfile
 ```
 
 ## PowerShell ISE/VSCode exploration


### PR DESCRIPTION
Breaking changes to the module's functionality per changes implemented by Medtronic:
- **Get-CareLinkToken**: With the introduction of a recaptcha on the login page, this cmdlet can no longer create a session capable of retrieving data. It has now been repurposed to get a token set via the new Set-CareLinkToken cmdlet
- **Get-CareLinkAccount** and **Get-CareLinkProfile**: no longer require the use of a Token parameter
- **Get-CareLinkData**: no longer requires the use of a Token parameter. Additionally, the endpoint to retrieve data has changed.
- **Confirm-CareLinkToken**: instead of initiating Get-CareLinkToken, now refreshes the current token with the sso re-auth endpoint
- **Set-CareLinkToken**: Introduced so as to set a valid token and token expiration date that has been obtained. This cmdlet must be used first before other commands can return data.